### PR TITLE
Update to mitsuba 3.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,7 @@ endif()
 
 if (NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/mitsuba.conf)
   if (APPLE)
-    set(MI_DEFAULT_VARIANTS "scalar_rgb,scalar_acoustic,metal_ad_rgb,llvm_ad_rgb,llvm_ad_acoustic" CACHE STRING "Default Mitsuba variants that should be included if no mitsuba.conf file exists")
+    set(MI_DEFAULT_VARIANTS "scalar_rgb,scalar_acoustic,llvm_acoustic,metal_acoustic,metal_ad_rgb,metal_ad_acoustic,llvm_ad_rgb,llvm_ad_acoustic" CACHE STRING "Default Mitsuba variants that should be included if no mitsuba.conf file exists")
   else()
     set(MI_DEFAULT_VARIANTS "scalar_rgb,scalar_acoustic,cuda_ad_rgb,cuda_ad_acoustic,llvm_ad_rgb,llvm_ad_acoustic" CACHE STRING "Default Mitsuba variants that should be included if no mitsuba.conf file exists")
   endif()

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It is a fully compatible extension to [Mitsuba 3](https://github.com/mitsuba-ren
 
 - **Cross-platform**: misuka has been tested on Linux (``x86_64``), macOS (``arm64``), and Windows (``x86_64``).
 
-- **High performance**: The underlying Dr.Jit compiler fuses rendering code into kernels that achieve state-of-the-art performance using an LLVM backend targeting the CPU and a CUDA/OptiX backend targeting NVIDIA GPUs with ray tracing hardware acceleration.
+- **High performance**: The underlying Dr.Jit compiler fuses rendering code into kernels that achieve state-of-the-art performance using an LLVM backend targeting the CPU, a CUDA/OptiX backend targeting NVIDIA GPUs, and a Metal backend targeting Apple Silicon GPUs, all with hardware-accelerated ray tracing.
 
 - **Python first**: misuka is deeply integrated with Python. Materials, textures, and even full rendering algorithms can be developed in Python, which the system JIT-compiles (and optionally differentiates) on the fly. This enables the experimentation needed for research.
 
@@ -42,6 +42,7 @@ Please refer the [Mitsuba 3 documentation](https://mitsuba.readthedocs.io/en/lat
 - `Python >= 3.9`
 - (optional) For computation on the GPU: `Nvidia driver >= 535`
 - (optional) For vectorized / parallel computation on the CPU: `LLVM >= 11.1`
+- (optional) For computation on Apple Silicon GPUs: macOS with a Metal-capable GPU
 
 When using misuka in academic projects, please cite:
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -12,6 +12,7 @@ Release notes
     - Add an energy-loss stopping criterion: paths terminate once their throughput drops below `max_energy_loss` in dB `[PR #4] <https://github.com/misuka-renderer/misuka/pull/4>`_
     - Add a `hide_emitters` option to exclude direct emitter contributions from the ETC `[PR #4] <https://github.com/misuka-renderer/misuka/pull/4>`_
 - Add a test pipeline for the acoustic AD integrators `[PR #4] <https://github.com/misuka-renderer/misuka/pull/4>`_
+- Update Mitsuba base to v3.9.0 `[PR #7] <https://github.com/misuka-renderer/misuka/pull/7>`_
 
 misuka 0.0.0
 ------------

--- a/resources/mitsuba.conf.template
+++ b/resources/mitsuba.conf.template
@@ -145,6 +145,16 @@
         "spectrum": "Spectrum<Float, 1>"
     },
 
+    "metal_acoustic": {
+        "float": "dr::MetalArray<float>",
+        "spectrum": "Spectrum<Float, 1>"
+    },
+
+    "metal_ad_acoustic": {
+        "float": "dr::DiffArray<JitBackend::Metal, float>",
+        "spectrum": "Spectrum<Float, 1>"
+    },
+
     # Scalar variant definitions
 
     "scalar_mono": {

--- a/src/bsdfs/acousticbsdf.cpp
+++ b/src/bsdfs/acousticbsdf.cpp
@@ -101,8 +101,8 @@ public:
 
     AcousticBSDF(const Properties &props) : Base(props) {
 
-        m_absorption = props.texture<Texture>("absorption", 0.5f);
-        m_scattering = props.texture<Texture>("scattering", 0.5f);
+        m_absorption = props.get_texture<Texture>("absorption", 0.5f);
+        m_scattering = props.get_texture<Texture>("scattering", 0.5f);
 
         // Beckmann distribution
         m_type           = MicrofacetType::Beckmann;
@@ -116,14 +116,11 @@ public:
         m_flags = m_components[0] | m_components[1];
     }
 
-    void traverse(TraversalCallback *callback) override {
-        callback->put_object("absorption", m_absorption.get(),
-                             +ParamFlags::Differentiable);
-        callback->put_object("scattering", m_scattering.get(),
-                             +ParamFlags::Differentiable);
-        callback->put_parameter("specular_lobe_width", m_alpha,
-                                ParamFlags::Differentiable |
-                                    ParamFlags::Discontinuous);
+    void traverse(TraversalCallback *cb) override {
+        cb->put("absorption", m_absorption, ParamFlags::Differentiable);
+        cb->put("scattering", m_scattering, ParamFlags::Differentiable);
+        cb->put("specular_lobe_width", m_alpha,
+                ParamFlags::Differentiable | ParamFlags::Discontinuous);
     }
 
     std::pair<BSDFSample3f, Spectrum> sample(const BSDFContext &ctx,
@@ -300,7 +297,7 @@ public:
         return oss.str();
     }
 
-    MI_DECLARE_CLASS()
+    MI_DECLARE_CLASS(AcousticBSDF)
 protected:
     ref<Texture> m_absorption;
     ref<Texture> m_scattering;
@@ -309,8 +306,9 @@ protected:
     MicrofacetType m_type;
     Float m_alpha;
     bool m_sample_visible;
+
+    MI_TRAVERSE_CB(Base, m_absorption, m_scattering, m_alpha)
 };
 
-MI_IMPLEMENT_CLASS_VARIANT(AcousticBSDF, BSDF)
-MI_EXPORT_PLUGIN(AcousticBSDF, "Acoustic material")
+MI_EXPORT_PLUGIN(AcousticBSDF)
 NAMESPACE_END(mitsuba)

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -104,23 +104,32 @@ for variant in all_possible_variants:
 
 # Create variant groups using the filter helper
 variant_groups = {
-    "any_scalar": v.all("scalar").one(),
-    "any_llvm": v.all("llvm").one(),
-    "any_cuda": v.all("cuda").one(),
-    "any_metal": v.all("metal").one(),
+    # "Optical" here means every non-acoustic (rgb/spectral/mono) variant --
+    # i.e. the variant families this test framework was originally written
+    # for, before misuka added the acoustic simulation extension. Upstream
+    # tests use e.g. variants_all/variants_all_scalar with no acoustic
+    # awareness at all, so those groups deliberately exclude "acoustic";
+    # use variants_all_acoustic (or a more specific acoustic group below)
+    # for acoustic-aware tests.
+    "any_scalar": v.all("scalar").exclude("acoustic").one(),
+    "any_llvm": v.all("llvm").exclude("acoustic").one(),
+    "any_cuda": v.all("cuda").exclude("acoustic").one(),
+    "any_metal": v.all("metal").exclude("acoustic").one(),
     "any_acoustic": v.all("acoustic").one(),
-    "all": v,
-    "all_scalar": v.all("scalar"),
+    "all": v.exclude("acoustic"),
+    "all_optical": v.exclude("acoustic"),
+    "all_scalar": v.all("scalar").exclude("acoustic"),
     "all_rgb": v.all("rgb"),
     "all_rgb_unpolarized": v.all("rgb").exclude("polarized"),
     "all_spectral": v.all("spectral"),
     "all_acoustic": v.all("acoustic"),
-    "all_backends_once": v.all("scalar").one()
-    + v.all("llvm").one()
-    + v.all("cuda").one()
-    + v.all("metal").one(),
-    "vec_backends_once": v.all("llvm").one() + v.all("cuda").one()
-    + v.all("metal").one(),
+    "all_backends_once": v.all("scalar").exclude("acoustic").one()
+    + v.all("llvm").exclude("acoustic").one()
+    + v.all("cuda").exclude("acoustic").one()
+    + v.all("metal").exclude("acoustic").one(),
+    "vec_backends_once": v.all("llvm").exclude("acoustic").one()
+    + v.all("cuda").exclude("acoustic").one()
+    + v.all("metal").exclude("acoustic").one(),
     "vec_backends_once_rgb": v.all("llvm", "rgb").one() + v.all("cuda", "rgb").one()
     + v.all("metal", "rgb").one(),
     "vec_backends_once_spectral": v.all("llvm", "spectral").one()

--- a/src/core/properties.cpp
+++ b/src/core/properties.cpp
@@ -602,7 +602,8 @@ ref<Object> Properties::get_texture_impl(std::string_view name,
     std::string_view plugin_name;
 
     // Determine variant properties
-    bool is_spectral      = variant.find("spectral") != std::string::npos,
+    bool is_spectral      = variant.find("spectral") != std::string::npos ||
+                            variant.find("acoustic") != std::string::npos,
          is_monochromatic = variant.find("mono")     != std::string::npos;
 
     switch (type) {

--- a/src/films/tape.cpp
+++ b/src/films/tape.cpp
@@ -28,7 +28,7 @@ public:
         // This is semantically inconsistent but no problem if we use frequencies everywhere consistently.
         if (props.type("frequencies") == Properties::Type::String) {
             std::vector<std::string> frequencies_str =
-                string::tokenize(props.string("frequencies"), " ,");
+                string::tokenize(props.get<std::string_view>("frequencies"), " ,");
 
             std::vector<ScalarFloat> frequencies;
             frequencies.reserve(frequencies_str.size());
@@ -65,11 +65,11 @@ public:
         m_count = props.get<bool>("count", false);
 
         std::string file_format = string::to_lower(
-            props.string("file_format", "openexr"));
+            props.get<std::string_view>("file_format", "openexr"));
         std::string pixel_format = string::to_lower(
-            props.string("pixel_format", "MultiChannel"));
+            props.get<std::string_view>("pixel_format", "MultiChannel"));
         std::string component_format = string::to_lower(
-            props.string("component_format", "float16"));
+            props.get<std::string_view>("component_format", "float16"));
 
         if (file_format == "openexr" || file_format == "exr")
             m_file_format = Bitmap::FileFormat::OpenEXR;
@@ -84,11 +84,11 @@ public:
         }
 
         if (component_format == "float16")
-            m_component_format = Struct::Type::Float16;
+            m_component_format = sj::Type::Float16;
         else if (component_format == "float32")
-            m_component_format = Struct::Type::Float32;
+            m_component_format = sj::Type::Float32;
         else if (component_format == "uint32")
-            m_component_format = Struct::Type::UInt32;
+            m_component_format = sj::Type::UInt32;
         else
             Throw("The \"component_format\" parameter must either be "
                   "equal to \"float16\", \"float32\", or \"uint32\"."
@@ -184,7 +184,7 @@ public:
             Throw("No storage allocated, was prepare() called first?");
 
         std::lock_guard<std::mutex> lock(m_mutex);
-        auto &&storage = dr::migrate(m_storage->tensor().array(), AllocType::Host);
+        auto &&storage = dr::migrate(m_storage->tensor().array(), JitBackend::None);
 
         if constexpr (dr::is_jit_v<Float>)
             dr::sync_thread();
@@ -240,7 +240,7 @@ public:
             // Conversion is necessary before saving to disk
             std::vector<std::string> channel_names;
             for (size_t i = 0; i < source->channel_count(); i++)
-                channel_names.push_back(source->struct_()->operator[](i).name);
+                channel_names.push_back(source->struct_()[i].name);
             ref<Bitmap> target = new Bitmap(
                 source->pixel_format(),
                 m_component_format,
@@ -276,17 +276,18 @@ public:
         return oss.str();
     }
 
-    MI_DECLARE_CLASS()
+    MI_DECLARE_CLASS(Tape)
 protected:
     Bitmap::FileFormat m_file_format;
-    Struct::Type m_component_format;
+    sj::Type m_component_format;
     ref<ImageBlock> m_storage;
     mutable std::mutex m_mutex;
     std::vector<std::string> m_channels;
     std::vector<ScalarFloat> m_frequencies;
     bool m_count;
+
+    MI_TRAVERSE_CB(Base, m_storage)
 };
 
-MI_IMPLEMENT_CLASS_VARIANT(Tape, Film)
-MI_EXPORT_PLUGIN(Tape, "Tape")
+MI_EXPORT_PLUGIN(Tape)
 NAMESPACE_END(mitsuba)

--- a/src/integrators/acoustic_path.cpp
+++ b/src/integrators/acoustic_path.cpp
@@ -696,7 +696,7 @@ public:
             << "\n  rr_depth = " << m_rr_depth << "\n  max_energy_loss = "
             << (m_throughput_threshold == 0.f
                     ? std::string("disabled")
-                    : (std::to_string(-10.0f * log10(m_throughput_threshold)) +
+                    : (std::to_string(-10.0f * static_cast<float>(log10(m_throughput_threshold))) +
                        " dB"))
             << "\n  hide_emitters = " << m_hide_emitters << "\n]";
         return oss.str();

--- a/src/integrators/acoustic_path.cpp
+++ b/src/integrators/acoustic_path.cpp
@@ -136,7 +136,7 @@ public:
 
     TensorXf render(Scene *scene,
                     Sensor *sensor,
-                    uint32_t seed,
+                    UInt32 seed,
                     uint32_t spp,
                     bool develop,
                     bool evaluate) override {
@@ -183,7 +183,7 @@ public:
         TensorXf result;
         if constexpr (!dr::is_jit_v<Float>) {
             // Render on the CPU using a spiral pattern
-            uint32_t n_threads = (uint32_t) Thread::thread_count();
+            uint32_t n_threads = (uint32_t) (pool_size() + 1);
 
             Log(Info, "Starting render job (%ux%u, %u sample%s,%s %u thread%s)",
                 film_size[0], film_size.y(), spp, spp == 1 ? "" : "s",
@@ -207,11 +207,9 @@ public:
             // Avoid overlaps in RNG seeding RNG when a seed is manually specified
             seed *= dr::prod(film_size);
 
-            ThreadEnvironment env;
             dr::parallel_for(
                 dr::blocked_range<uint32_t>(0, total_blocks, 1),
                 [&](const dr::blocked_range<uint32_t> &range) {
-                    ScopedSetThreadEnvironment set_env(env);
                     // Fork a non-overlapping sampler for the current worker
                     ref<Sampler> sampler = sensor->sampler()->fork();
 
@@ -723,7 +721,7 @@ public:
             return dr::fmadd(a, b, c);
     }
 
-    MI_DECLARE_CLASS()
+    MI_DECLARE_CLASS(AcousticPathIntegrator)
 
 protected:
 
@@ -769,6 +767,5 @@ protected:
     float m_throughput_threshold;
 };
 
-MI_IMPLEMENT_CLASS_VARIANT(AcousticPathIntegrator, MonteCarloIntegrator)
-MI_EXPORT_PLUGIN(AcousticPathIntegrator, "Acoustic Path Tracer integrator");
+MI_EXPORT_PLUGIN(AcousticPathIntegrator)
 NAMESPACE_END(mitsuba)

--- a/src/integrators/tests/test_acoustic_ad_integrators.py
+++ b/src/integrators/tests/test_acoustic_ad_integrators.py
@@ -29,6 +29,7 @@ from mitsuba.scalar_acoustic import ScalarTransform4f as T
 import drjit as dr
 import mitsuba as mi
 
+import numpy as np
 import pytest
 import os
 import argparse
@@ -37,6 +38,13 @@ from os.path import join, exists
 
 from mitsuba.scalar_rgb.test.util import fresolver_append_path
 from mitsuba.scalar_rgb.test.util import find_resource
+
+# Cross-backend (LLVM <-> Metal) equivalence helpers live in the sibling test
+# module; pytest's default import mode puts this directory on sys.path.
+from test_acoustic_path import (
+    PRIMAL_PAIR, AD_PAIR, require_pair, render_on_variant,
+    assert_direct_sound_present, assert_etc_equivalent, assert_grad_equivalent,
+)
 
 output_dir = find_resource('resources/data_acoustic/tests/integrators')
 
@@ -735,6 +743,115 @@ def test13_ad_prb_equivalence(variants_all_ad_acoustic, ad_name, prb_name, confi
         print(f"-> abs diff: {diff}")
         print(f"-> rel diff: {rel}")
         pytest.fail(f"{ad_name} and {prb_name} disagree on gradient!")
+
+
+# -------------------------------------------------------------------
+#            LLVM <-> Metal equivalence (forward, then backward)
+# -------------------------------------------------------------------
+
+# Integrators whose primal render / backward gradient are compared across
+# backends. Forward-mode is compared for `acoustic_ad` only (see below).
+EQUIV_INTEGRATORS = ['acoustic_ad', 'acoustic_prb']
+
+EQUIV_SEED = 0
+EQUIV_SPP  = 2 ** 16
+EQUIV_GRAD_IN = 0.001
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize('integrator_name', EQUIV_INTEGRATORS)
+@pytest.mark.parametrize('config', BASIC_CONFIGS_LIST)
+def test14_llvm_metal_equivalence_primal(integrator_name, config):
+    """Primal ETCs must match across LLVM and Metal, direct sound included."""
+    require_pair(AD_PAIR)
+    name = config().name
+
+    def build_and_render():
+        cfg = config()
+        cfg.initialize()
+        cfg.integrator_dict['type'] = integrator_name
+        integrator = mi.load_dict(cfg.integrator_dict)
+        return integrator.render(cfg.scene, seed=EQUIV_SEED, spp=EQUIV_SPP)
+
+    ref  = render_on_variant(AD_PAIR[0], build_and_render)  # llvm
+    test = render_on_variant(AD_PAIR[1], build_and_render)  # metal
+
+    label = f"{integrator_name}/{name} (primal)"
+    assert_direct_sound_present(ref, test, label=label)
+    assert_etc_equivalent(ref, test, label=label)
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize('integrator_name', EQUIV_INTEGRATORS)
+@pytest.mark.parametrize('config', BASIC_CONFIGS_LIST)
+def test15_llvm_metal_equivalence_backward(integrator_name, config):
+    """Backward gradients w.r.t. the scene parameter must match across backends."""
+    require_pair(AD_PAIR)
+    name = config().name
+
+    def compute_grad():
+        cfg = config()
+        cfg.spp = EQUIV_SPP
+        cfg.initialize()
+        cfg.integrator_dict['type'] = integrator_name
+        integrator = mi.load_dict(cfg.integrator_dict)
+
+        # Size the adjoint buffer from a cheap primal render.
+        shape = integrator.render(cfg.scene, seed=EQUIV_SEED, spp=1).shape
+        etc_adj = dr.full(mi.TensorXf, EQUIV_GRAD_IN, shape)
+
+        theta = mi.Float(0.0)
+        dr.enable_grad(theta)
+        dr.set_label(theta, 'theta')
+        cfg.update(theta)
+
+        integrator.render_backward(cfg.scene, grad_in=etc_adj, seed=EQUIV_SEED,
+                                   spp=EQUIV_SPP, params=theta)
+        return dr.grad(theta)
+
+    grad_llvm  = render_on_variant(AD_PAIR[0], compute_grad)
+    grad_metal = render_on_variant(AD_PAIR[1], compute_grad)
+
+    assert_grad_equivalent(grad_llvm, grad_metal,
+                           label=f"{integrator_name}/{name} (backward)")
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize('config', BASIC_CONFIGS_LIST)
+def test16_llvm_metal_equivalence_forward(config):
+    """Forward-mode gradient ETCs must match across backends (acoustic_ad only;
+    acoustic_prb has no render_forward)."""
+    require_pair(AD_PAIR)
+    name = config().name
+
+    def compute_forward():
+        cfg = config()
+        cfg.spp = EQUIV_SPP
+        cfg.initialize()
+        cfg.integrator_dict['type'] = 'acoustic_ad'
+        integrator = mi.load_dict(cfg.integrator_dict)
+
+        theta = mi.Float(0.0)
+        dr.enable_grad(theta)
+        dr.set_label(theta, 'theta')
+        cfg.update(theta)
+        # Push the gradient from theta into the scene parameters before
+        # render_forward so the forward AD traversal inside the loop sees it
+        # (mirrors the wiring of the skipped test11).
+        dr.forward(theta, dr.ADFlag.ClearEdges)
+
+        etc_fwd = integrator.render_forward(cfg.scene, seed=EQUIV_SEED,
+                                            spp=EQUIV_SPP, params=theta)
+        return dr.detach(etc_fwd)
+
+    ref  = render_on_variant(AD_PAIR[0], compute_forward)  # llvm
+    test = render_on_variant(AD_PAIR[1], compute_forward)  # metal
+
+    # Forward-mode gradients are signed and may contain near-cancellations, so
+    # compare with the relative+floor ETC helper (looser than primal) rather than
+    # the direct-sound peak check.
+    assert_etc_equivalent(ref, test, label=f"acoustic_ad/{name} (forward)",
+                          rtol=1e-1, atol_frac=5e-2)
 
 
 # -------------------------------------------------------------------

--- a/src/integrators/tests/test_acoustic_ad_integrators.py
+++ b/src/integrators/tests/test_acoustic_ad_integrators.py
@@ -463,6 +463,136 @@ def test10_rendering_primal(variants_all_ad_acoustic, integrator_name, config):
         pytest.fail("ETC values exceeded configuration's tolerances!")
 
 
+def _finite_depth_scene(scattering, time_bins=40):
+    """A small enclosed shoebox with a flat (mesh-based) emitter and an
+    omnidirectional microphone, used to exercise the direct sound and
+    first-order reflections at small, *finite* path depths.
+
+    Deliberately uses a ``rectangle`` emitter rather than a ``sphere``: while
+    investigating this bug, driving the JIT (``llvm_ad_acoustic``) acoustic
+    integrators against a *sphere* emitter (Embree "user geometry", traced via
+    the per-shape ``ray_intersect_preliminary_packet`` callback in
+    ``src/render/embree.h``) triggered an intermittent, pre-existing
+    segfault inside Embree's packet intersector for user geometry. That crash:
+      * reproduces with this fix stashed out (i.e. it predates and is
+        unrelated to the ordering bug fixed here),
+      * lives entirely in generic, unmodified upstream Mitsuba/Embree
+        infrastructure (``src/render/embree.h``, ``src/shapes/sphere.cpp``
+        have no misuka-specific changes),
+      * appears to be a timing-sensitive data race (its trigger rate was not a
+        clean function of scene parameters), consistent with concurrent
+        access to a shape from multiple Embree/nanothread worker threads.
+    A ``rectangle`` is internally a two-triangle ``Mesh`` and is intersected
+    through Embree's native triangle geometry path instead, which does not
+    exercise the affected callback; it reproduces the reported bug just as
+    well (any smooth emitter shape triggers the missing-emitter-hit bug) and
+    was empirically stable across many repeated runs. The sphere/Embree crash
+    is a separate, serious finding that deserves its own follow-up
+    investigation and is out of scope for the specular/direct-sound fixes
+    made here.
+    """
+    return {
+        'type': 'scene',
+        'shoebox': {
+            'type': 'cube',
+            'flip_normals': True,
+            'to_world': T().scale([7, 5, 3]),
+            'bsdf': {
+                'type': 'acousticbsdf',
+                'specular_lobe_width': 0.001,
+                'absorption': {'type': 'spectrum', 'value': [(250, 0.1), (500, 0.1)]},
+                'scattering': {'type': 'spectrum', 'value': [(250, scattering), (500, scattering)]},
+            },
+        },
+        'rect_emitter': {
+            'type': 'rectangle',
+            'to_world': T().translate([2, 0, 0]).rotate(axis=[0, 1, 0], angle=90).scale(0.5),
+            'flip_normals': True,  # face the rectangle towards the microphone
+            'emitter': {'type': 'area', 'radiance': {'type': 'uniform', 'value': 1}},
+        },
+        'sensor': {
+            'type': 'microphone',
+            'origin': [-2, 0, 0],
+            'direction': [1, 0, 0],
+            'kappa': 0,
+            'film': {
+                'type': 'tape',
+                'rfilter': {'type': 'box'},
+                'sample_border': False,
+                'pixel_format': 'MultiChannel',
+                'component_format': 'float32',
+                'frequencies': '250, 500',
+                'time_bins': time_bins,
+            },
+        },
+    }
+
+
+def test10b_finite_depth_emitter_hits(variant_llvm_ad_acoustic):
+    """Regression test: the AD/PRB integrators must record the direct-emission
+    contribution (``Le``) whenever a traced ray hits an emitter, *including* at
+    the terminal path depth.
+
+    A bug in the PRB integrators gated the ``Le`` splat on the ``active_next``
+    mask *after* it had been reduced by ``depth + 1 < max_depth``. That silently
+    dropped:
+      * the direct (line-of-sight) sound when ``max_depth == 1``, and
+      * specular reflections captured by BSDF sampling at the final bounce.
+        Specular energy reaches a point microphone almost exclusively through
+        such emitter hits (next-event estimation contributes ~nothing for a
+        near-delta lobe), so the specular component of the ETC went missing.
+
+    The existing primal tests only use ``max_depth == -1`` (infinite), where the
+    terminal depth is never reached, so they could not catch this. Here we use
+    small finite depths and compare against the reference ``acoustic_path``
+    integrator, which handles these contributions correctly.
+
+    The check is restricted to a single JIT backend on purpose: the bug lives in
+    backend-independent Python code, and driving several of these Python
+    integrators across multiple variants in one process trips an unrelated,
+    pre-existing crash (see the notes in the accompanying fix).
+    """
+    spp = 2 ** 14
+    seed = 0
+
+    def render(itype, max_depth, scattering):
+        scene = mi.load_dict(_finite_depth_scene(scattering))
+        integrator = mi.load_dict({
+            'type': itype,
+            'speed_of_sound': 340,
+            'max_time': 0.2,
+            'max_depth': max_depth,
+            'max_energy_loss': -1,
+        }, parallel=False)
+        return integrator.render(scene, seed=seed, spp=spp)
+
+    # Reference contributions from the (correct) acoustic_path integrator.
+    ref_direct = dr.sum(render('acoustic_path', 1, 0.05), axis=None)   # direct sound
+    ref_spec   = dr.sum(render('acoustic_path', 2, 0.05), axis=None)   # + specular refl.
+
+    # The specular first-order reflection must add meaningful energy on top of
+    # the direct sound, otherwise there is nothing to detect as "missing".
+    assert ref_spec > 1.1 * ref_direct
+
+    for integrator_name in ('acoustic_prb', 'acoustic_prb_threepoint'):
+        # max_depth == 1: direct sound only. Must be non-zero (was 0.0) and
+        # match the reference.
+        etc_direct = render(integrator_name, 1, 0.05)
+        assert dr.max(dr.abs(etc_direct)) > 0.0, \
+            f"{integrator_name}: direct sound missing at max_depth=1"
+        assert dr.allclose(dr.sum(etc_direct, axis=None), ref_direct, rtol=1e-2), \
+            f"{integrator_name}: direct sound energy disagrees with acoustic_path"
+
+        # max_depth == 2, low scattering: the first-order reflection is almost
+        # purely specular and is captured via an emitter hit at the terminal
+        # bounce. Must match the reference (was ~missing before the fix).
+        etc_spec = dr.sum(render(integrator_name, 2, 0.05), axis=None)
+        assert dr.allclose(etc_spec, ref_spec, rtol=2e-2), \
+            f"{integrator_name}: specular first reflection disagrees with acoustic_path"
+        assert etc_spec > 1.1 * dr.sum(etc_direct, axis=None), \
+            f"{integrator_name}: specular first reflection contributes no energy"
+
+
 @pytest.mark.slow
 @pytest.mark.skip(reason="Gradient estimation will be tested in a future PR.")
 @pytest.mark.skipif(os.name == 'nt', reason='Skip those memory heavy tests on Windows')

--- a/src/integrators/tests/test_acoustic_ad_integrators.py
+++ b/src/integrators/tests/test_acoustic_ad_integrators.py
@@ -65,7 +65,7 @@ def test01_initialization(variants_all_jit_acoustic, integrator_name):
                                'speed_of_sound': 343.0}, parallel=False)
     assert isinstance(integrator, mi.CppADIntegrator)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(RuntimeError, match='max_time'):
         mi.load_dict({'type': integrator_name, 'max_time': -1})
 
 @pytest.mark.parametrize('integrator_name', INTEGRATORS)
@@ -109,21 +109,21 @@ def test03_constructor_custom_values(variants_all_jit_acoustic, integrator_name)
 @pytest.mark.parametrize('integrator_name', INTEGRATORS)
 def test04_constructor_max_time_missing(variants_all_jit_acoustic, integrator_name):
     """max_time is required and must raise ValueError if missing."""
-    with pytest.raises(ValueError):
+    with pytest.raises(RuntimeError, match='max_time'):
         mi.load_dict({'type': integrator_name})
 
 @pytest.mark.parametrize('integrator_name', INTEGRATORS)
 def test05_constructor_max_time_zero(variants_all_jit_acoustic, integrator_name):
     """max_time=0 must raise ValueError."""
-    with pytest.raises(ValueError):
+    with pytest.raises(RuntimeError, match='max_time'):
         mi.load_dict({'type': integrator_name, 'max_time': 0.0})
 
 @pytest.mark.parametrize('integrator_name', INTEGRATORS)
 def test06_constructor_speed_of_sound_invalid(variants_all_jit_acoustic, integrator_name):
     """speed_of_sound <= 0 must raise ValueError."""
-    with pytest.raises(ValueError):
+    with pytest.raises(RuntimeError, match='speed_of_sound'):
         mi.load_dict({'type': integrator_name, 'max_time': 1.0, 'speed_of_sound': 0.0})
-    with pytest.raises(ValueError):
+    with pytest.raises(RuntimeError, match='speed_of_sound'):
             mi.load_dict({'type': integrator_name, 'max_time': 1.0, 'speed_of_sound': -1.0})
 
 @pytest.mark.parametrize('integrator_name', INTEGRATORS)
@@ -154,9 +154,9 @@ def test08_constructor_rr_depth_invalid(variants_all_jit_acoustic, integrator_na
 @pytest.mark.parametrize('integrator_name', INTEGRATORS)
 def test09_constructor_max_energy_loss_invalid(variants_all_jit_acoustic, integrator_name):
     """max_energy_loss < 0 (and not -1) must raise ValueError."""
-    with pytest.raises(ValueError):
+    with pytest.raises(RuntimeError, match='max_energy_loss'):
         mi.load_dict({'type': integrator_name, 'max_time': 1.0, 'max_energy_loss': -2.0})
-    with pytest.raises(ValueError):
+    with pytest.raises(RuntimeError, match='max_energy_loss'):
         mi.load_dict({'type': integrator_name, 'max_time': 1.0, 'max_energy_loss': 0.0})
 
     # -1 (disabled) is valid

--- a/src/integrators/tests/test_acoustic_ad_integrators.py
+++ b/src/integrators/tests/test_acoustic_ad_integrators.py
@@ -39,8 +39,9 @@ from os.path import join, exists
 from mitsuba.scalar_rgb.test.util import fresolver_append_path
 from mitsuba.scalar_rgb.test.util import find_resource
 
-# Cross-backend (LLVM <-> Metal) equivalence helpers live in the sibling test
-# module; pytest's default import mode puts this directory on sys.path.
+# Cross-backend equivalence helpers live in test_acoustic_path.py.
+import sys
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from test_acoustic_path import (
     PRIMAL_PAIR, AD_PAIR, require_pair, render_on_variant,
     assert_direct_sound_present, assert_etc_equivalent, assert_grad_equivalent,
@@ -771,7 +772,9 @@ def test14_llvm_metal_equivalence_primal(integrator_name, config):
         cfg.initialize()
         cfg.integrator_dict['type'] = integrator_name
         integrator = mi.load_dict(cfg.integrator_dict)
-        return integrator.render(cfg.scene, seed=EQUIV_SEED, spp=EQUIV_SPP)
+        result = integrator.render(cfg.scene, seed=EQUIV_SEED, spp=EQUIV_SPP)
+        dr.eval(result)
+        return result
 
     ref  = render_on_variant(AD_PAIR[0], build_and_render)  # llvm
     test = render_on_variant(AD_PAIR[1], build_and_render)  # metal
@@ -807,7 +810,9 @@ def test15_llvm_metal_equivalence_backward(integrator_name, config):
 
         integrator.render_backward(cfg.scene, grad_in=etc_adj, seed=EQUIV_SEED,
                                    spp=EQUIV_SPP, params=theta)
-        return dr.grad(theta)
+        grad = dr.grad(theta)
+        dr.eval(grad)
+        return grad
 
     grad_llvm  = render_on_variant(AD_PAIR[0], compute_grad)
     grad_metal = render_on_variant(AD_PAIR[1], compute_grad)
@@ -842,7 +847,9 @@ def test16_llvm_metal_equivalence_forward(config):
 
         etc_fwd = integrator.render_forward(cfg.scene, seed=EQUIV_SEED,
                                             spp=EQUIV_SPP, params=theta)
-        return dr.detach(etc_fwd)
+        result = dr.detach(etc_fwd)
+        dr.eval(result)
+        return result
 
     ref  = render_on_variant(AD_PAIR[0], compute_forward)  # llvm
     test = render_on_variant(AD_PAIR[1], compute_forward)  # metal

--- a/src/integrators/tests/test_acoustic_path.py
+++ b/src/integrators/tests/test_acoustic_path.py
@@ -70,10 +70,17 @@ def _variant_cleanup():
 
 
 def render_on_variant(variant, build_and_render):
-    """Set `variant`, run `build_and_render()` (which builds the scene + integrator
-    and returns a drjit/mitsuba result), copy the result to a host NumPy array, and
-    clean up. All variant-specific objects are created and destroyed inside the
-    chosen variant."""
+    """Set `variant`, run `build_and_render()` (which builds the scene + integrator,
+    renders, and must `dr.eval()` its result before returning -- see below),
+    copy the result to a host NumPy array, and clean up. All variant-specific
+    objects are created and destroyed inside the chosen variant.
+
+    `build_and_render` must force its result with `dr.eval()` *before*
+    returning it, not leave it lazily pending: Mitsuba objects it creates as
+    locals (the scene, in particular) are only kept alive by that function's
+    own frame, and become eligible for garbage collection the moment it
+    returns. A value still lazily pending at that point can end up evaluated
+    later against a since-collected scene and crash."""
     mi.set_variant(variant)
     try:
         result = build_and_render()
@@ -479,7 +486,9 @@ def test09_llvm_metal_equivalence_primal(config):
         cfg.initialize()
         cfg.integrator_dict['type'] = 'acoustic_path'
         integrator = mi.load_dict(cfg.integrator_dict, parallel=False)
-        return integrator.render(cfg.scene, seed=seed, spp=spp)
+        result = integrator.render(cfg.scene, seed=seed, spp=spp)
+        dr.eval(result)
+        return result
 
     ref  = render_on_variant(PRIMAL_PAIR[0], build_and_render)  # llvm
     test = render_on_variant(PRIMAL_PAIR[1], build_and_render)  # metal

--- a/src/integrators/tests/test_acoustic_path.py
+++ b/src/integrators/tests/test_acoustic_path.py
@@ -2,6 +2,7 @@
 import drjit as dr
 import mitsuba as mi
 
+import numpy as np
 import pytest
 import os
 import argparse
@@ -17,6 +18,132 @@ output_dir = find_resource('resources/data_acoustic/tests/integrators')
 # Directory next to this test file where rendered ETCs and reference copies are
 # written on failure, so they can be inspected/plotted (see plot_etcs.py).
 tests_dir = os.path.dirname(os.path.abspath(__file__))
+
+
+# -------------------------------------------------------------------
+#              Cross-backend (LLVM <-> Metal) equivalence
+# -------------------------------------------------------------------
+#
+# These helpers render the *same* scene on two backends and compare the
+# resulting ETCs / gradients. Unlike the regression tests above (which compare a
+# single variant against a stored .exr), they catch backend-specific divergences
+# such as the Metal backend dropping the direct sound. They deliberately do NOT
+# use the `variants_*` fixtures from conftest.py (which parametrize a single
+# variant per test) -- instead each test drives both variants internally,
+# rebuilding the scene under each because Mitsuba types are variant-specific.
+
+# Non-`ad` pair for primal (forward) rendering, `ad` pair for gradients.
+PRIMAL_PAIR = ('llvm_acoustic', 'metal_acoustic')
+AD_PAIR     = ('llvm_ad_acoustic', 'metal_ad_acoustic')
+
+
+def _backend_available(variant):
+    """True if `variant` is compiled and its JIT backend is live at runtime."""
+    if variant not in mi.variants():
+        return False
+    if variant.startswith('llvm'):
+        return dr.has_backend(dr.JitBackend.LLVM)
+    if variant.startswith('metal'):
+        return dr.has_backend(dr.JitBackend.Metal)
+    if variant.startswith('cuda'):
+        return dr.has_backend(dr.JitBackend.CUDA)
+    return True
+
+
+def require_pair(pair):
+    """Skip the test unless both variants of `pair` are usable."""
+    missing = [v for v in pair if not _backend_available(v)]
+    if missing:
+        pytest.skip(f"cross-backend equivalence needs {pair}; unavailable: {missing}")
+
+
+def _variant_cleanup():
+    """Same teardown conftest.py runs between variant-scoped tests, so switching
+    variants mid-test does not leak kernels/instances across backends."""
+    dr.sync_thread()
+    dr.flush_kernel_cache()
+    dr.kernel_history_clear()
+    dr.flush_malloc_cache()
+    dr.detail.malloc_clear_statistics()
+    dr.detail.clear_registry()
+    dr.set_flag(dr.JitFlag.Default, True)
+
+
+def render_on_variant(variant, build_and_render):
+    """Set `variant`, run `build_and_render()` (which builds the scene + integrator
+    and returns a drjit/mitsuba result), copy the result to a host NumPy array, and
+    clean up. All variant-specific objects are created and destroyed inside the
+    chosen variant."""
+    mi.set_variant(variant)
+    try:
+        result = build_and_render()
+        arr = np.array(result, dtype=np.float64)
+    finally:
+        _variant_cleanup()
+    return arr
+
+
+def _dump_pair(label, ref, test):
+    """Write both ETCs next to the test file for inspection on failure."""
+    safe = label.replace('/', '_').replace(' ', '_')
+    for tag, arr in (('llvm_ref', ref), ('metal_test', test)):
+        try:
+            path = join(tests_dir, f"equiv_{safe}_{tag}.exr")
+            mi.util.write_bitmap(path, mi.TensorXf(np.asarray(arr, dtype=np.float32)))
+            print(f"-> wrote {path}")
+        except Exception as e:  # dumping is best-effort
+            print(f"-> could not write {tag}: {e}")
+
+
+def assert_direct_sound_present(ref, test, *, label, min_ratio=0.5):
+    """Assert the strongest bin of the reference ETC (the direct arrival) is also
+    present, with comparable energy, on the test backend. This is the assertion
+    that directly targets the reported Metal 'missing direct sound' symptom."""
+    ref = np.asarray(ref, dtype=np.float64)
+    test = np.asarray(test, dtype=np.float64)
+    assert ref.shape == test.shape, \
+        f"{label}: shape mismatch {test.shape} != {ref.shape}"
+    idx = np.unravel_index(int(np.argmax(np.abs(ref))), ref.shape)
+    ref_peak = float(ref[idx])
+    test_val = float(test[idx])
+    assert ref_peak > 0, f"{label}: reference ETC has no signal"
+    if test_val <= min_ratio * ref_peak:
+        _dump_pair(label, ref, test)
+        pytest.fail(
+            f"{label}: direct sound missing/attenuated on test backend at bin "
+            f"{idx}: ref={ref_peak:.4g} test={test_val:.4g} "
+            f"(need >= {min_ratio:g}x)")
+
+
+def assert_etc_equivalent(ref, test, *, label, rtol=5e-2, atol_frac=2e-2):
+    """Compare two ETCs bin-by-bin with a relative tolerance plus a floor
+    (`atol_frac` * reference peak) so near-zero bins don't dominate."""
+    ref = np.asarray(ref, dtype=np.float64)
+    test = np.asarray(test, dtype=np.float64)
+    assert ref.shape == test.shape, \
+        f"{label}: shape mismatch {test.shape} != {ref.shape}"
+    peak = float(np.max(np.abs(ref)))
+    atol = atol_frac * peak
+    if not np.allclose(test, ref, rtol=rtol, atol=atol):
+        denom = np.maximum(np.abs(ref), atol)
+        rel = np.abs(test - ref) / denom
+        _dump_pair(label, ref, test)
+        pytest.fail(
+            f"{label}: ETCs differ (rel err max={rel.max():.3g} "
+            f"mean={rel.mean():.3g}, peak={peak:.3g}, "
+            f"rtol={rtol:g} atol={atol:.3g})")
+
+
+def assert_grad_equivalent(ref, test, *, label, rtol=5e-2, atol=1e-6):
+    """Compare gradients from two backends, failing on NaN/Inf or disagreement."""
+    ref = np.asarray(ref, dtype=np.float64)
+    test = np.asarray(test, dtype=np.float64)
+    assert np.all(np.isfinite(ref)), f"{label}: llvm gradient not finite: {ref}"
+    assert np.all(np.isfinite(test)), f"{label}: metal gradient not finite: {test}"
+    if not np.allclose(test, ref, rtol=rtol, atol=atol):
+        pytest.fail(
+            f"{label}: gradients differ llvm={ref.ravel()} metal={test.ravel()} "
+            f"(rtol={rtol:g} atol={atol:g})")
 
 def test01_constructor_valid(variants_all_acoustic):
     """Test that the integrator can be constructed with valid parameters."""
@@ -331,6 +458,35 @@ def test08_rendering_primal(variants_all_acoustic, integrator_name, config):
         mi.util.write_bitmap(filename_ref, etc_ref)
         pytest.fail("ETC values exceeded configuration's tolerances!")
 
+
+# -------------------------------------------------------------------
+#            LLVM <-> Metal forward-rendering equivalence
+# -------------------------------------------------------------------
+
+@pytest.mark.slow
+@pytest.mark.parametrize('config', CONFIGS_LIST)
+def test09_llvm_metal_equivalence_primal(config):
+    """`acoustic_path` must produce the same ETC on the LLVM and Metal backends,
+    including the direct sound (strongest arrival)."""
+    require_pair(PRIMAL_PAIR)
+
+    seed = 0
+    spp = 2 ** 16
+    name = config().name
+
+    def build_and_render():
+        cfg = config()
+        cfg.initialize()
+        cfg.integrator_dict['type'] = 'acoustic_path'
+        integrator = mi.load_dict(cfg.integrator_dict, parallel=False)
+        return integrator.render(cfg.scene, seed=seed, spp=spp)
+
+    ref  = render_on_variant(PRIMAL_PAIR[0], build_and_render)  # llvm
+    test = render_on_variant(PRIMAL_PAIR[1], build_and_render)  # metal
+
+    label = f"acoustic_path/{name}"
+    assert_direct_sound_present(ref, test, label=label)
+    assert_etc_equivalent(ref, test, label=label)
 
 
 # -------------------------------------------------------------------

--- a/src/python/python/ad/integrators/acoustic_ad.py
+++ b/src/python/python/ad/integrators/acoustic_ad.py
@@ -559,15 +559,18 @@ class AcousticADIntegrator(RBIntegrator):
             with dr.resume_grad():
                 # Launch the Monte Carlo sampling process in primal mode (1)
                 # Contrary to the light case we already need the input gradient as we return δH dot L to avoid storing L which is a function.
-                self.sample(
-                    scene=scene,
-                    sampler=sampler.clone(),
-                    sensor=sensor,
-                    ray=ray,
-                    block=block,
-                    position_sample=position_sample,
-                    active=mi.Bool(True)
-                )
+                # Disable symbolic loops because we write to one external block
+                # and symbolic-loop AD can't differentiate scatters into external buffers.
+                with dr.scoped_set_flag(dr.JitFlag.SymbolicLoops, False):
+                    self.sample(
+                        scene=scene,
+                        sampler=sampler.clone(),
+                        sensor=sensor,
+                        ray=ray,
+                        block=block,
+                        position_sample=position_sample,
+                        active=mi.Bool(True)
+                    )
 
                 film.put_block(block)
                 result_img = film.develop()
@@ -611,15 +614,18 @@ class AcousticADIntegrator(RBIntegrator):
             with dr.resume_grad():
                 # Launch the Monte Carlo sampling process in primal mode (1)
                 # Contrary to the light case we already need the input gradient as we return δH dot L to avoid storing L which is a function.
-                self.sample(
-                    scene=scene,
-                    sampler=sampler.clone(),
-                    sensor=sensor,
-                    ray=ray,
-                    block=block,
-                    position_sample=position_sample,
-                    active=mi.Bool(True)
-                )
+                # Disable symbolic loops because we write to one external block
+                # and symbolic-loop AD can't differentiate scatters into external buffers.
+                with dr.scoped_set_flag(dr.JitFlag.SymbolicLoops, False):
+                    self.sample(
+                        scene=scene,
+                        sampler=sampler.clone(),
+                        sensor=sensor,
+                        ray=ray,
+                        block=block,
+                        position_sample=position_sample,
+                        active=mi.Bool(True)
+                    )
 
                 film.put_block(block)
                 result_img = film.develop()

--- a/src/python/python/ad/integrators/acoustic_prb.py
+++ b/src/python/python/ad/integrators/acoustic_prb.py
@@ -167,6 +167,15 @@ class AcousticPRBIntegrator(AcousticADIntegrator):
 
             # ---------------------- Emitter sampling ----------------------
 
+            # The direct emission recorded above must be splatted whenever we
+            # actually hit an emitter, even at the maximum depth (e.g. the
+            # direct sound for max_depth == 1, or a specular reflection captured
+            # by BSDF sampling at the final bounce). Capture that mask *before*
+            # restricting `active_next` to continuable paths, otherwise these
+            # contributions are silently discarded. This mirrors the ordering in
+            # AcousticADIntegrator.sample().
+            active_direct = active_next & si.is_valid()
+
             # Should we continue tracing to reach one more vertex?
             active_next &= (depth + 1 < self.max_depth) & si.is_valid()
 
@@ -247,7 +256,7 @@ class AcousticPRBIntegrator(AcousticADIntegrator):
             else: # primal
                 block.put(pos=Le_pos,
                           values=film.prepare_sample(Le[0], si.wavelengths, n_channels),
-                          active=active_next & (Le[0] > 0.))
+                          active=active_direct & (Le[0] > 0.))
                 block.put(pos=Lr_dir_pos,
                           values=film.prepare_sample(Lr_dir[0], si.wavelengths, n_channels),
                           active=active_em & (Lr_dir[0] > 0.))

--- a/src/python/python/ad/integrators/acoustic_prb_threepoint.py
+++ b/src/python/python/ad/integrators/acoustic_prb_threepoint.py
@@ -195,6 +195,15 @@ class AcousticPRBThreePointIntegrator(AcousticADIntegrator):
 
             # ---------------------- Emitter sampling ----------------------
 
+            # The direct emission recorded above must be splatted whenever we
+            # actually hit an emitter, even at the maximum depth (e.g. the
+            # direct sound for max_depth == 1, or a specular reflection captured
+            # by BSDF sampling at the final bounce). Capture that mask *before*
+            # restricting `active_next` to continuable paths, otherwise these
+            # contributions are silently discarded. This mirrors the ordering in
+            # AcousticADIntegrator.sample().
+            active_direct = mi.Bool(active_next)
+
             # Should we continue tracing to reach one more vertex?
             active_next &= (depth + 1 < self.max_depth)
 
@@ -286,7 +295,7 @@ class AcousticPRBThreePointIntegrator(AcousticADIntegrator):
             else: # primal
                 block.put(pos=Le_pos,
                           values=film.prepare_sample(Le[0], si.wavelengths, n_channels),
-                          active=active_next & (Le[0] > 0.))
+                          active=active_direct & (Le[0] > 0.))
                 block.put(pos=Lr_dir_pos,
                           values=film.prepare_sample(Lr_dir[0], si.wavelengths, n_channels),
                           active=active_em & (Lr_dir[0] > 0.))

--- a/src/sensors/microphone.cpp
+++ b/src/sensors/microphone.cpp
@@ -35,7 +35,7 @@ public:
                 ScalarPoint3f target = origin + direction;
                 auto [up, unused] = coordinate_system(dr::normalize(direction));
 
-                m_to_world = ScalarTransform4f::look_at(origin, target, up);
+                m_to_world = ScalarAffineTransform4f::look_at(origin, target, up);
                 dr::make_opaque(m_to_world);
             }
         }
@@ -113,8 +113,8 @@ public:
         if (dr::none_or<false>(active))
             return { ds, dr::zeros<Spectrum>() };
 
-        Transform4f trafo     = m_to_world.value();
-        Transform4f trafo_inv = trafo.inverse();
+        AffineTransform4f trafo     = m_to_world.value();
+        AffineTransform4f trafo_inv = trafo.inverse();
 
         ds.p                 = trafo.translation();
         ds.d                 = ds.p - it.p;
@@ -156,11 +156,10 @@ public:
 
     // TODO: traverse() needed?
 
-    MI_DECLARE_CLASS()
+    MI_DECLARE_CLASS(Microphone)
 protected:
     Float m_kappa;
 };
 
-MI_IMPLEMENT_CLASS_VARIANT(Microphone, Sensor)
-MI_EXPORT_PLUGIN(Microphone, "Microphone");
+MI_EXPORT_PLUGIN(Microphone)
 NAMESPACE_END(mitsuba)


### PR DESCRIPTION
This PR Bumps the Mitsuba base version from v3.6.4 to v3.9.0.

Squash-merged our commits onto the v3.9.0 tag and ported the acoustic plugins to the new APIs (plugin macros, Properties, Transform types, struct-jit, ImageBlock accumulation).

Two changes bugs introduces the version bump:
- Properties::get_texture_impl didn't know about the acoustic variant, so per-frequency spectra were silently getting RGB-fitted into garbage values.
- The new parser wraps Python-plugin constructor exceptions into RuntimeError instead of the original type — updated our tests accordingly.

The variant groups `variants_all`/`variants_all_scalar` in conftest.py are only used by mitsuba. Now they exclude acoustic variants, since upstream tests using those fixtures have no acoustic awareness.

Running both cuda_ad_rgb and cuda_ad_acoustic in the same test session causes some BoundingBox3f/BoundingSphere3f tests to fail.
This doesn't happen on a vanilla v3.9.0 build. Will look into this later.

- [x] CMake configure succeeds
- [x] ninja build completes
- [x] pytest src -m "not slow" passes (acoustic tests run, not skipped)
- [x] full pytest src passes except the 3 known CUDA-variant-registration failures above
- [x] Test if vanilla v3.9.0 tests fail when enabling more variants (cuda_ad_spectral, etc.) -> they don't
- [x] Fix remaining failing tests (some fixes in mitsuba / drjit core were necessary, these will be committed separately so they can be unrolled once the fixes are merged into the upstream repos)
- [x] Update release notes
- [x] Add metal acoustic variants to mitsuba.conf.template
- [x] add metal variants as default on mac
- [x] Test metal backend
- [x] Write to do list for future mitsuba base version updates
- [x] merge README.md